### PR TITLE
[PRO-65] Fix Shell Race Condition

### DIFF
--- a/Sources/SwiftyScripty/Extensions/FileHandle+Extensions.swift
+++ b/Sources/SwiftyScripty/Extensions/FileHandle+Extensions.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension FileHandle {
+    func setReadabilityHandler(_ handler: @escaping (FileHandle) async -> Void) {
+        readabilityHandler = { handle in
+            Task { await handler(handle) }
+        }
+    }
+
+    func setStringHandler(_ handler: @escaping (String) async -> Void) {
+        readabilityHandler = { handle in
+            guard let str = String(data: handle.availableData, encoding: .utf8), !str.isEmpty else { return }
+
+            Task { await handler(str) }
+        }
+    }
+}

--- a/Sources/SwiftyScripty/Process+LineReader.swift
+++ b/Sources/SwiftyScripty/Process+LineReader.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+extension ProcessRunnerImpl {
+    /// An actor used to ensure thread safeness when reading the input pipe.
+    /// The input pipe should not be read until we encounter the `scriptStartToken`
+    /// so the purpose of this actor is to provide thread safe access to the `shouldStartPrint` variable that
+    /// informs the pipe whether we can read the output or not.
+    actor ReadHandlerActor {
+        // MARK: - Properties
+
+        private var shouldStartPrint: Bool
+
+        // MARK: - Init
+
+        init() { shouldStartPrint = false }
+
+        // MARK: - Methods
+
+        func setStartPrint() {
+            shouldStartPrint = true
+        }
+
+        func canPrint() -> Bool {
+            shouldStartPrint
+        }
+    }
+}
+
+extension ProcessRunnerImpl {
+    /// An enum storing all the tokens used by a script while executing.
+    enum Separator {
+        static let scriptStartToken = "<--SwiftyScripty Interactive Shell Start-->"
+        static let scriptExitCodeTokenStart = "<--SwiftyScripty Interactive Shell EXIT CODE: "
+        static let scriptExitCodeToken = "\(scriptExitCodeTokenStart){$?}-->"
+        static let scriptEndToken = "<--SwiftyScripty Interactive Shell End-->"
+        static let scriptErrorPipeEndToken = "<--SwiftyScripty Interactive Shell Error End-->"
+    }
+
+    /// An enum capable of reading a series of lines from a raw output, and turn them in
+    /// tokens that we can use to know which line we had read.
+    enum Line {
+        /// The line indicating the beginning of the script.
+        case startToken
+
+        /// A single output line of the script.
+        case line(text: String)
+
+        /// A line indicating the exit code of the script.
+        case commandExitCode(code: Int32)
+
+        /// A line indicating the end of reading, so that the read pipe can be closed.
+        case endToken
+
+        /// A line indicating the end of reading for the error pipe, so that the read error pipe can be closed.
+        case endErrorToken
+
+        // MARK: - Init
+
+        init(from data: String) {
+            if data == Separator.scriptStartToken {
+                self = .startToken
+            } else if data == Separator.scriptEndToken {
+                self = .endToken
+            } else if data.starts(with: Separator.scriptExitCodeTokenStart) {
+                self = .commandExitCode(code: Self.extractCode(from: data) ?? .successExitCode)
+            } else if data == Separator.scriptErrorPipeEndToken {
+                self = .endErrorToken
+            } else {
+                self = .line(text: data)
+            }
+        }
+
+        // MARK: - Helper Functions
+
+        static func getLines(from output: String) -> [Line] {
+            output.split(separator: "\n").map { Line(from: String($0)) }
+        }
+
+        static func extractCode(from token: String) -> Int32? {
+            if
+                let startRange = token.range(of: "{"),
+                let endRange = token.range(of: "}", range: startRange.upperBound..<token.endIndex),
+                let exitCode = Int32(String(token[startRange.upperBound..<endRange.lowerBound]))
+            {
+                return exitCode
+            } else {
+                return nil
+            }
+        }
+    }
+}

--- a/Sources/SwiftyScripty/Utils/TaskProvider.swift
+++ b/Sources/SwiftyScripty/Utils/TaskProvider.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum TaskProvider {
+    static func cancellableContinuationTask<Result>(
+        for continuationBody: @escaping (UnsafeContinuation<Result, any Error>) -> Void,
+        onCancel: @escaping () -> Void
+    ) -> Task<Result, any Error> {
+        return Task {
+            var heldContinuation: UnsafeContinuation<Result, any Error>?
+            let onCancelHandler = {
+                onCancel()
+                heldContinuation?.resume(throwing: TaskError.continuationCancelled)
+            }
+
+            return try await withTaskCancellationHandler {
+                try await withUnsafeThrowingContinuation { continuation in
+                    heldContinuation = continuation
+                    continuationBody(continuation)
+                }
+            } onCancel: {
+                onCancelHandler()
+            }
+        }
+    }
+}
+
+enum TaskError: Error {
+    case continuationCancelled
+}


### PR DESCRIPTION
## Bug introduction

This bug was introduced when the shell was refactored to await pipes to be read before returning.
The shell was modified to use `pipe.fileHandleForReading.bytes.lines` instead of `pipe.fileHandleForReading.readabilityHandler`.

While this changed allowed us to have an easier handling for processes, it came with a specific issue.
The `bytes.lines` method is serialised. This means that the pipe is not readable by any thread if another thread is writing on it.
If we try to run a process that outputs more data than the size of the pipe, the process is blocked while writing, waiting for the pipe to be emptied. The problem is since the write/read process is serialized, the `bytes.lines` method cannot read the pipe while is being written, causing a deadlock between the write and the read process.

## Resolution

To solve this specific issue, the code was refactored in the following ways:

- The `bytes.lines` method was replaced with the old readability handler. This way the process is able to read the pipe while the other is writing it.
- The `bytes.lines` method though was added because sometimes the process was not able to read the whole pipe before terminating, so by returning to the old method, this issue appeared again.
- To solve this, an `echo` command was added after the real one, to be able to understand when the pipe has finished reading.
- Doing this though caused another issue. The process returns always success exit code, since it is the one of the last echo and not the real one.
- To solve this last issue, the real command was run in a subshell, and the exit code was redirected to a specific string, that we are able to read before printing the exit code. With this last change we are able to read the whole output and return the exit code.
